### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,9 @@
 
 name: .NET
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/Zefek/OdectyMVC/security/code-scanning/12](https://github.com/Zefek/OdectyMVC/security/code-scanning/12)

Add an explicit `permissions` block to `.github/workflows/build.yml` at the workflow root (right after `name` or after `on`) so it applies to all jobs unless overridden.  
For this workflow, the minimal safe setting is:

- `contents: read`

This preserves existing behavior (`checkout` can read repo contents; artifact upload does not require repo write scope) while enforcing least privilege and satisfying CodeQL.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
